### PR TITLE
Barcode128 only allows C code charset

### DIFF
--- a/ESC-POS-USB-NET/Enums/BarCodeCharSet.cs
+++ b/ESC-POS-USB-NET/Enums/BarCodeCharSet.cs
@@ -1,0 +1,14 @@
+﻿namespace ESC_POS_USB_NET.Enums
+{
+   ///<Summary>
+   /// This enum is used to set postion of barcode label
+   /// </Summary>
+
+    public enum BarCodeCharSet
+    {
+        A= 'A',
+        B= 'B',
+        C= 'C'
+    }
+}
+

--- a/ESC-POS-USB-NET/Enums/BarCodeCharSet.cs
+++ b/ESC-POS-USB-NET/Enums/BarCodeCharSet.cs
@@ -1,9 +1,5 @@
 ﻿namespace ESC_POS_USB_NET.Enums
 {
-   ///<Summary>
-   /// This enum is used to set postion of barcode label
-   /// </Summary>
-
     public enum BarCodeCharSet
     {
         A= 'A',

--- a/ESC-POS-USB-NET/Epson Commands/BarCode.cs
+++ b/ESC-POS-USB-NET/Epson Commands/BarCode.cs
@@ -6,7 +6,7 @@ namespace ESC_POS_USB_NET.EpsonCommands
 {
     public class BarCode : IBarCode
     {
-        public byte[] Code128(string code,Positions printString=Positions.NotPrint)
+        public byte[] Code128(string code,Positions printString=Positions.NotPrint, BarCodeCharSet codeSet = BarCodeCharSet.C)
         {
             return new byte[] { 29, 119, 2 } // Width
                 .AddBytes(new byte[] { 29, 104, 50 }) // Height
@@ -14,7 +14,7 @@ namespace ESC_POS_USB_NET.EpsonCommands
                 .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
                 .AddBytes(new byte[] { 29, 107, 73 }) // printCode
                 .AddBytes(new[] { (byte)(code.Length + 2) })
-                .AddBytes(new[] { '{'.ToByte(), 'C'.ToByte() })
+                .AddBytes(new[] { '{'.ToByte(), codeSet.ToByte() })
                 .AddBytes(code)
                 .AddLF();
         }

--- a/ESC-POS-USB-NET/Interfaces/Command/IBarCode.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IBarCode.cs
@@ -4,7 +4,7 @@ namespace ESC_POS_USB_NET.Interfaces.Command
 {
     interface IBarCode
     {
-        byte[] Code128(string code,Positions printString);
+        byte[] Code128(string code,Positions printString, BarCodeCharSet codeSet);
         byte[] Code39(string code, Positions printString);
         byte[] Ean13(string code, Positions printString);
     }

--- a/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
+++ b/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
@@ -41,7 +41,7 @@ namespace ESC_POS_USB_NET.Interfaces.Printer
         void Image(Bitmap image);
         void QrCode(string qrData);
         void QrCode(string qrData, QrCodeSize qrCodeSize);
-        void Code128(string code, Positions positions);
+        void Code128(string code, Positions positions, BarCodeCharSet codeCharSet);
         void Code39(string code, Positions positions);
         void Ean13(string code, Positions positions);
         void InitializePrint();

--- a/ESC-POS-USB-NET/Printer.cs
+++ b/ESC-POS-USB-NET/Printer.cs
@@ -269,9 +269,9 @@ namespace ESC_POS_USB_NET.Printer
             Append(_command.QrCode.Print(qrData, qrCodeSize));
         }
 
-        public void Code128(string code, Positions printString = Positions.NotPrint)
+        public void Code128(string code, Positions printString = Positions.NotPrint, BarCodeCharSet codeCharSet = BarCodeCharSet.C)
         {
-            Append(_command.BarCode.Code128(code,  printString));
+            Append(_command.BarCode.Code128(code,  printString, codeCharSet));
         }
 
         public void Code39(string code, Positions printString=Positions.NotPrint)


### PR DESCRIPTION
In some cases, Barcode128 would be nice to use charset A or B, so adding a charset as optional parameter allows to print 128 with numbers and letters