### PR TITLE
Combined features from few PRs into one + some other additions and dual-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+## # commit: # (2024-03-30 ??:??GMT+1)
+More PRs combined into this one...
+
+#### Changes:
+- Added more sizes to enum `enums/QrCodeSize.cs`: 
+  - Added `Size6`..`Size13` = `9dots`..`16dots`.
+- `Epson Commands/FontMode.cs` added:
+  - `Reverse(PrinterModeState)` - set Reverse mode (allow to print text inverted/negative: black background/white text)
+  - `Reverse(string)` - print text in Reverse mode (inverted/negative), and return back to normal mode,
+  - `ReverseNoLF(string)` - print text in Reverse mode (inverted/negative), and return back to normal mode, but don't add `LF` (new line) at end of text.
+- `Interfaces/Command/IFontMode.cs` - Updated interfaces definitions.
+- `Printer.cs`:
+  - Added functions for Reverse mode (inverted/negative print) 
+    - `ReverseMode` ,
+    - `ReverseModeNoLF` ,
+  - Updated `TestPrint` for Reverse test prints,
+  - Added function `Image` with `scaleToWidth` parameter,
+- `Interfaces/IPrint.cs`
+  - Updated for Reverse routines definitions,
+  - updated for `Image` new function,
+- `Epson Commands/Image.cs` updated:
+  - function `GetBitmapData`:
+    - added parameter `scaleToWidth` (default **true**), if `false` image won't be up-scaled to printhead dot count (printing width), **BUT:** image will be still down-scaled if is wider that printhead print width (printhead dot count).
+  - function `IImage.Print`:
+    - added parameter `scaleToWidth` with default **true** value.
+
+-----
+## # commit: #6aabcac (2024-03-29 23:55GMT+1)
+Modified (extended) multiple barcode function for more settings. Also changed image rendering function to be more universal.
+
+#### Changes:
+- Added enums for BarCodes `enums/BarCode.cs`:
+  - `BarCodeCode128Charset` - Charsets for Code-128 (Inspired by: https://github.com/mtmsuhail/ESC-POS-USB-NET/pull/38 ):
+    - `A` - charset A,
+    - `B` - charset B,
+    - `C` - charset C.
+  - `BarCodeBarWidth` - To set thin-bar width (barcode modulo):
+    - `Width0125` - thin bar of width 1dot (0.125mm),
+    - `Width0250` - thin bar of width 2dots (0.250mm) - **default width**,
+    - `Width0375` - thin bar of width 3dots (0.375mm),
+    - `Width0500` - thin bar of width 4dots (0.500mm),
+- Added enums for QRCode
+  - `enums/QrCodeError.cs` - for error level correction:
+    - `L` = 48 - default,
+    - `M` = 49,
+    - `Q` = 50,
+    - `H` = 51.
+  - `enums/QrCodeModel.cs` - for different QrCode models, :warning: some (Chinese especially) printers don't support this. *(will be explained in functions description)*:
+    - `Model1` = 49,
+    - `Model2` = 50,
+    - `Model3Micro` = 51, *Micro QR* ( [Epson: GS(k<Function 165>](https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_lk_fn165.html) )
+  - `enums/QrCodeSize.cs` - for different code sizes (why not if it's possible :grin: ):
+    - `Size000` - modulo 1 (1dot) *for ppl having hawk-eyes :laughing:*,
+    - `Size00` - modulo 2 (2dots),
+    - `Size0` - modulo 3 (3dots) *(original size value)*,
+    - `Size1` - modulo 4 (4dots) *(original size value)*,
+    - `Size2` - modulo 5 (5dots) *(original size value)*,
+    - `Size3` - modulo 6 (6dots),
+    - `Size4` - modulo 7 (7dots),
+    - `Size5` - modulo 8 (8dots).  
+- added functions:
+  - `Epson Commands/BarCode.cs`:
+    - `Code128` that can take `byte[] code` instead of string (**Charset=C**),
+    - `Code128` with options: 
+      - `startCharset` enum: `BarCodeCode128Charset`, 
+      - `barWidth` enum: `BarCodeBarWidth`, 
+      - `codeHeight` byte - height in dots, default `50`=6.25mm.
+    - `Code39` with options: 
+      - `barWidth` enum: `BarCodeBarWidth`, 
+      - `codeHeight` byte - height in dots, default `50`=6.25mm.
+    - `Ean13` with options: 
+      - `barWidth` enum: `BarCodeBarWidth`, 
+      - `codeHeight` byte - height in dots, default `50`=6.25mm.
+  - `Epson Commands/Image.cs`:
+    - Added to `Print` parameter that allow changing `DotsInLine` more easily (not hardcoded in lib). This parameter define how image is resized and must be same as your printer printhead dot count.
+  - `Epson Commands/QrCode.cs`:
+    - `Print` with options: 
+      - `QrCodeErrorCorrection` enum, 
+      - `QrCodeModel` enum, 
+      - `NoFun165` bool. 
+      :warning: :warning: :warning: There are some (Chinese) printers that don't digest command `GS(k<func:165>` **Set QrCode Model** and instead ignoring it , they print some text (e.g.: `MPT-II` print text `2` :unamused: ) - this is the reason for `NoFun165` parameter - it'll suppress adding this command.
+    - added some comments,
+  - `Interfaces/Command/*.cs` - updated with new function definitions.
+  - `Interfaces/Printer/IPrinter.cs` - updated with new function definitions.
+  - `Printer.cs` 
+    - added **read-only** property `Buffer` to take a peek into commands buffer that's going to be printed,
+    - added property `DotsInLine` to set printer printhead dots count - this is needed by `Image` function to properly render image. Default `576`.
+    - added function for extended Barcodes routines (`Ean13`,`Code128`,`Code39`,`QrCode.Print`).
+
+----
+## # commit: #e039c3d (2024-03-29 23:43GMT+1)
+Modified csproj file so VS will build not only `netstandard2.0` but also `net45` binary too. 
+This should make things easier for some people that don't want just to add bunch of other libraries (related to `netstandard2.0`) to only add this one while using netFramework 4.5 or newer.
+
+---
+## # source commit: #ff50466

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## # commit: # (2024-03-30 ??:??GMT+1)
+## # commit: #6842df1 (2024-03-30 14:53GMT+1)
 More PRs combined into this one...
+
+Added [file for some details about different printers](SPECIFIC-PRINTER-INFO.md) .
 
 #### Changes:
 - Added more sizes to enum `enums/QrCodeSize.cs`: 
@@ -15,9 +17,11 @@ More PRs combined into this one...
     - `ReverseModeNoLF` ,
   - Updated `TestPrint` for Reverse test prints,
   - Added function `Image` with `scaleToWidth` parameter,
+  - Added another function `Code128(string)` that have only one parameter *(VS complains that it can't decide which function to pick if it have one parameter)*
 - `Interfaces/IPrint.cs`
   - Updated for Reverse routines definitions,
   - updated for `Image` new function,
+  - updated for `Code128` new function,
 - `Epson Commands/Image.cs` updated:
   - function `GetBitmapData`:
     - added parameter `scaleToWidth` (default **true**), if `false` image won't be up-scaled to printhead dot count (printing width), **BUT:** image will be still down-scaled if is wider that printhead print width (printhead dot count).

--- a/ESC-POS-USB-NET/ESC-POS-USB-NET.csproj
+++ b/ESC-POS-USB-NET/ESC-POS-USB-NET.csproj
@@ -4,7 +4,7 @@
     <Authors>MTM Suhail
 </Authors>
     <ApplicationVersion>1.0.0</ApplicationVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>ESC_POS_USB_NET</RootNamespace>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Drawing.Common" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/ESC-POS-USB-NET/Enums/BarCode.cs
+++ b/ESC-POS-USB-NET/Enums/BarCode.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ESC_POS_USB_NET.Enums
+{
+    // Insipired by https://github.com/mtmsuhail/ESC-POS-USB-NET/pull/38/commits/fc5cb17a798093bbf8e1a376e35051f1fc1a9ff7
+    public enum BarCodeCode128Charset
+    {
+        A = 'A',
+        B = 'B',
+        C = 'C'
+    }
+
+    /// <summary>
+    /// Bar code thin-bar width
+    /// </summary>
+    public enum BarCodeBarWidth
+    {
+        Width0125 = 1,
+        /// <summary>
+        /// Default width
+        /// </summary>
+        Width0250 = 2,
+        Width0375 = 3,
+        Width0500 = 4
+    }
+}

--- a/ESC-POS-USB-NET/Enums/QrCodeError.cs
+++ b/ESC-POS-USB-NET/Enums/QrCodeError.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ESC_POS_USB_NET.Enums
+{
+    public enum QrCodeErrorCorrection
+    {
+        L = 48,
+        M = 49,
+        Q = 50,
+        H = 51
+    }
+}

--- a/ESC-POS-USB-NET/Enums/QrCodeModel.cs
+++ b/ESC-POS-USB-NET/Enums/QrCodeModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ESC_POS_USB_NET.Enums
+{
+    public enum QrCodeModel
+    {
+        Model1 = 49,
+        Model2 = 50,
+        Model3Micro = 51
+    }
+}

--- a/ESC-POS-USB-NET/Enums/QrCodeSize.cs
+++ b/ESC-POS-USB-NET/Enums/QrCodeSize.cs
@@ -12,7 +12,18 @@
         // extended by more sizes
         Size3, //=6
         Size4, //=7
-        Size5  //=8
+        Size5,  //=8
+        Size6,  //=9
+        Size7,  //=10
+        Size8,  //=11
+        Size9,  //=12
+        Size10, //=13
+        Size11, //=14
+        Size12, //=15
+        Size13, //=16
+
     }
+    // no need for all those sizes (up to 16dots/module) :-) , I don't see use for biggers than Size5 (8dots) , but let it's have it...
+    // https://github.com/mtmsuhail/ESC-POS-USB-NET/pull/22 :-D
 }
 

--- a/ESC-POS-USB-NET/Enums/QrCodeSize.cs
+++ b/ESC-POS-USB-NET/Enums/QrCodeSize.cs
@@ -2,9 +2,17 @@
 {
     public enum QrCodeSize
     {
-        Size0,
-        Size1,
-        Size2
+        // extended by more sizes
+        Size000 = -2, //-2+3=1
+        Size00=-1, // -1+3=2
+        // original sizes
+        Size0, //0+3=3
+        Size1, //=4
+        Size2, //=5
+        // extended by more sizes
+        Size3, //=6
+        Size4, //=7
+        Size5  //=8
     }
 }
 

--- a/ESC-POS-USB-NET/Epson Commands/BarCode.cs
+++ b/ESC-POS-USB-NET/Epson Commands/BarCode.cs
@@ -6,6 +6,12 @@ namespace ESC_POS_USB_NET.EpsonCommands
 {
     public class BarCode : IBarCode
     {
+        /// <summary>
+        /// Create Code-128 barcode. Use C charset.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <returns></returns>
         public byte[] Code128(string code,Positions printString=Positions.NotPrint)
         {
             return new byte[] { 29, 119, 2 } // Width
@@ -19,6 +25,48 @@ namespace ESC_POS_USB_NET.EpsonCommands
                 .AddLF();
         }
 
+        /// <summary>
+        /// Create Code-128 barcode. Use C charset.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <returns></returns>
+        public byte[] Code128(byte[] code, Positions printString = Positions.NotPrint)
+        {
+            return new byte[] { 29, 119, 2 } // Width
+                .AddBytes(new byte[] { 29, 104, 50 }) // Height
+                .AddBytes(new byte[] { 29, 102, 1 }) // font hri character
+                .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
+                .AddBytes(new byte[] { 29, 107, 73 }) // printCode
+                .AddBytes(new[] { (byte)(code.Length + 2) })
+                .AddBytes(new[] { '{'.ToByte(), 'C'.ToByte() })
+                .AddBytes(code)
+                .AddLF();
+        }
+
+        /// <summary>
+        /// Create Code-128 barcode. With option to set Code128 charset.
+        /// Insipred by @https://github.com/mtmsuhail/ESC-POS-USB-NET/pull/38/commits/fc5cb17a798093bbf8e1a376e35051f1fc1a9ff7
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <param name="startCharset"></param>
+        /// <returns></returns>
+        public byte[] Code128(string code, Positions printString = Positions.NotPrint, BarCodeCode128Charset startCharset= BarCodeCode128Charset.C, BarCodeBarWidth barWidth=BarCodeBarWidth.Width0250, byte codeHeight=50)
+        {
+            return new byte[] { 29, 119, (byte)barWidth } // Width
+                .AddBytes(new byte[] { 29, 104, codeHeight }) // Height
+                .AddBytes(new byte[] { 29, 102, 1 }) // font hri character
+                .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
+                .AddBytes(new byte[] { 29, 107, 73 }) // printCode
+                .AddBytes(new[] { (byte)(code.Length + 2) })
+                .AddBytes(new[] { '{'.ToByte(), startCharset.ToByte() })
+                .AddBytes(code)
+                .AddLF();
+        }
+
+
+
         public byte[] Code39(string code, Positions printString = Positions.NotPrint)
         {
             return new byte[] { 29, 119, 2 } // Width
@@ -31,6 +79,27 @@ namespace ESC_POS_USB_NET.EpsonCommands
                 .AddLF();
         }
 
+        /// <summary>
+        /// Generate Code-39 barcode.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <param name="barWidth"></param>
+        /// <param name="codeHeight"></param>
+        /// <returns></returns>
+        public byte[] Code39(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50)
+        {
+            return new byte[] { 29, 119, (byte)barWidth } // Width
+                .AddBytes(new byte[] { 29, 104, codeHeight }) // Height
+                .AddBytes(new byte[] { 29, 102, 0 }) // font hri characterset (A)
+                .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
+                .AddBytes(new byte[] { 29, 107, 4 })
+                .AddBytes(code)
+                .AddBytes(new byte[] { 0 })
+                .AddLF();
+        }
+
+
         public byte[] Ean13(string code, Positions printString = Positions.NotPrint)
         {
             if (code.Trim().Length != 13)
@@ -38,6 +107,27 @@ namespace ESC_POS_USB_NET.EpsonCommands
 
             return new byte[] { 29, 119, 2 } // Width
                 .AddBytes(new byte[] { 29, 104, 50 }) // Height
+                .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
+                .AddBytes(new byte[] { 29, 107, 67, 12 })
+                .AddBytes(code.Substring(0, 12))
+                .AddLF();
+        }
+
+        /// <summary>
+        /// Generate EAN-13 code.
+        /// </summary>
+        /// <param name="code">EAN-13 13digit string</param>
+        /// <param name="printString"></param>
+        /// <param name="barWidth">Width of thin-bar in barcode</param>
+        /// <param name="codeHeight">Height on barcode (in dots)</param>
+        /// <returns></returns>
+        public byte[] Ean13(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight=50)
+        {
+            if (code.Trim().Length != 13)
+                return new byte[0];
+
+            return new byte[] { 29, 119, (byte)barWidth } // Width
+                .AddBytes(new byte[] { 29, 104, codeHeight }) // Height
                 .AddBytes(new byte[] { 29, 72, printString.ToByte() }) // If print code informed
                 .AddBytes(new byte[] { 29, 107, 67, 12 })
                 .AddBytes(code.Substring(0, 12))

--- a/ESC-POS-USB-NET/Epson Commands/FontMode.cs
+++ b/ESC-POS-USB-NET/Epson Commands/FontMode.cs
@@ -123,6 +123,29 @@ namespace ESC_POS_USB_NET.EpsonCommands
             }
             return new byte[] { 27, 'M'.ToByte(), fnt };
         }
+
+        //  https://github.com/mtmsuhail/ESC-POS-USB-NET/pull/47 
+        public byte[] Reverse(PrinterModeState state)
+        {
+            return state == PrinterModeState.On
+                ? new byte[] { 29, 'B'.ToByte(), 1 }
+                : new byte[] { 29, 'B'.ToByte(), 0 };
+        }
+
+        public byte[] Reverse(string value)
+        {
+            return Reverse(PrinterModeState.On)
+                .AddBytes(value)
+                .AddBytes(Reverse(PrinterModeState.Off))
+                .AddLF();
+        }
+
+        public byte[] ReverseNoLF(string value)
+        {
+            return Reverse(PrinterModeState.On)
+                .AddBytes(value)
+                .AddBytes(Reverse(PrinterModeState.Off));
+        }
     }
 }
 

--- a/ESC-POS-USB-NET/Epson Commands/Image.cs
+++ b/ESC-POS-USB-NET/Epson Commands/Image.cs
@@ -2,18 +2,24 @@
 using System;
 using System.IO;
 using ESC_POS_USB_NET.Interfaces.Command;
+//#if NETSTANDARD2_0
 using System.Drawing;
+//#else
+//using System.Drawing;
+//#endif
 
 namespace ESC_POS_USB_NET.EpsonCommands
 {
     public class Image : IImage
     {
-        private static BitmapData GetBitmapData(Bitmap bmp)
+
+
+        private static BitmapData GetBitmapData(Bitmap bmp, int dotsInLine=576)
         {
   
                 var threshold = 127;
                 var index = 0;
-                double multiplier = 576; // this depends on your printer model.
+                double multiplier = dotsInLine * 1.0; // this depends on your printer model.
                 double scale = (double)(multiplier / (double)bmp.Width);
                 int xheight = (int)(bmp.Height * scale);
                 int xwidth = (int)(bmp.Width * scale);
@@ -39,12 +45,25 @@ namespace ESC_POS_USB_NET.EpsonCommands
                     Height = (int)(bmp.Height * scale),
                     Width = (int)(bmp.Width * scale)
                 };
-       
+
         }
 
-        byte[] IImage.Print(Bitmap image)
+
+        /// DotsInLine:
+        /// This depends on your printer head, most common printers have 203dpi that is 8dot/1mm.Usually printer have about 5mm margins too.
+        /// High Resolution print heads have 300dpi, that is about 12dots/1mm but those are much more expensive and less popular.
+        /// Usually this is in Printer specification table in your printeer manual.
+        /// So if you have printer for 58mm ribbon(57mm), then: 58mm - (2x5mm margin) = 48mm active area, then knowing 8dots/1mm: 48*8=384 dots
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="image"></param>
+        /// <param name="DotsInLine">This depends on your printer head</param>
+        /// <returns></returns>
+        byte[] IImage.Print(Bitmap image, int DotsInLine)
         {
-            var data = GetBitmapData(image);
+            var data = GetBitmapData(image, DotsInLine);
             BitArray dots = data.Dots;
             byte[] width = BitConverter.GetBytes(data.Width);
 
@@ -52,9 +71,10 @@ namespace ESC_POS_USB_NET.EpsonCommands
             MemoryStream stream = new MemoryStream();
             BinaryWriter bw = new BinaryWriter(stream);
 
+            // reset printer settings
             bw.Write((char)0x1B);
             bw.Write('@');
-
+            // set line height to 24dots - because we're using 24dots height mode
             bw.Write((char)0x1B);
             bw.Write('3');
             bw.Write((byte)24);
@@ -63,7 +83,7 @@ namespace ESC_POS_USB_NET.EpsonCommands
             {
                 bw.Write((char)0x1B);
                 bw.Write('*');         // bit-image mode
-                bw.Write((byte)33);    // 24-dot double-density
+                bw.Write((byte)33);    // 24-dot double-density ; some printers have 24-dot single-width
                 bw.Write(width[0]);  // width low byte
                 bw.Write(width[1]);  // width high byte
 

--- a/ESC-POS-USB-NET/Interfaces/Command/IBarCode.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IBarCode.cs
@@ -5,8 +5,12 @@ namespace ESC_POS_USB_NET.Interfaces.Command
     interface IBarCode
     {
         byte[] Code128(string code,Positions printString);
+        byte[] Code128(byte[] code,Positions printString);
+        byte[] Code128(string code,Positions printString, BarCodeCode128Charset startCharset= BarCodeCode128Charset.C, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50);
         byte[] Code39(string code, Positions printString);
+        byte[] Code39(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50);
         byte[] Ean13(string code, Positions printString);
+        byte[] Ean13(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50);
     }
 }
 

--- a/ESC-POS-USB-NET/Interfaces/Command/IFontMode.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IFontMode.cs
@@ -14,6 +14,10 @@ namespace ESC_POS_USB_NET.Interfaces.Command
         byte[] Condensed(PrinterModeState state);
         byte[] Font(string value, Fonts state);
         byte[] Font(Fonts state);
+        byte[] Reverse(PrinterModeState state);
+        byte[] Reverse(string value);
+        byte[] ReverseNoLF(string value);
+        
     }
 }
 

--- a/ESC-POS-USB-NET/Interfaces/Command/IImage.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IImage.cs
@@ -6,6 +6,6 @@ namespace ESC_POS_USB_NET.Interfaces.Command
     {
         
 
-        byte[] Print(Bitmap image, int DotsInLine);
+        byte[] Print(Bitmap image, int DotsInLine, bool scaleToWidth=true);
     }
 }

--- a/ESC-POS-USB-NET/Interfaces/Command/IImage.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IImage.cs
@@ -4,6 +4,8 @@ namespace ESC_POS_USB_NET.Interfaces.Command
 {
     internal interface IImage
     {
-        byte[] Print(Bitmap image);
+        
+
+        byte[] Print(Bitmap image, int DotsInLine);
     }
 }

--- a/ESC-POS-USB-NET/Interfaces/Command/IQrCode.cs
+++ b/ESC-POS-USB-NET/Interfaces/Command/IQrCode.cs
@@ -6,6 +6,7 @@ namespace ESC_POS_USB_NET.Interfaces.Command
     {
         byte[] Print(string qrData);
         byte[] Print(string qrData, QrCodeSize qrCodeSize);
+        byte[] Print(string qrData, QrCodeSize qrCodeSize, QrCodeErrorCorrection errorCorrection, QrCodeModel qrModel, bool NoFun165);
     }
 }
 

--- a/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
+++ b/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
@@ -39,6 +39,7 @@ namespace ESC_POS_USB_NET.Interfaces.Printer
         void PartialPaperCut();
         void OpenDrawer();
         void Image(Bitmap image);
+        void Image(Bitmap image, bool scaleToWidth);
         void QrCode(string qrData);
         void QrCode(string qrData, QrCodeSize qrCodeSize);
         /// <summary>
@@ -50,6 +51,7 @@ namespace ESC_POS_USB_NET.Interfaces.Printer
         /// <param name="qrModel"></param>
         /// <param name="NoFun165">Some, especially CN printers don't support this command (set QrCode Model) and print instead some text</param>
         void QrCode(string qrData, QrCodeSize qrCodeSize, QrCodeErrorCorrection errorCorrection, QrCodeModel qrModel, bool NoFun165);
+        void Code128(string code);
         void Code128(string code, Positions positions);
         void Code128(byte[] code, Positions positions);
         void Code128(string code, Positions positions, BarCodeCode128Charset startCharset, BarCodeBarWidth barWidth, byte codeHeight);

--- a/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
+++ b/ESC-POS-USB-NET/Interfaces/Printer/IPrinter.cs
@@ -41,9 +41,22 @@ namespace ESC_POS_USB_NET.Interfaces.Printer
         void Image(Bitmap image);
         void QrCode(string qrData);
         void QrCode(string qrData, QrCodeSize qrCodeSize);
+        /// <summary>
+        /// Create QR Code with more parameters
+        /// </summary>
+        /// <param name="qrData"></param>
+        /// <param name="qrCodeSize"></param>
+        /// <param name="errorCorrection"></param>
+        /// <param name="qrModel"></param>
+        /// <param name="NoFun165">Some, especially CN printers don't support this command (set QrCode Model) and print instead some text</param>
+        void QrCode(string qrData, QrCodeSize qrCodeSize, QrCodeErrorCorrection errorCorrection, QrCodeModel qrModel, bool NoFun165);
         void Code128(string code, Positions positions);
+        void Code128(byte[] code, Positions positions);
+        void Code128(string code, Positions positions, BarCodeCode128Charset startCharset, BarCodeBarWidth barWidth, byte codeHeight);
         void Code39(string code, Positions positions);
+        void Code39(string code, Positions positions, BarCodeBarWidth barWidth, byte codeHeight);
         void Ean13(string code, Positions positions);
+        void Ean13(string code, Positions positions, BarCodeBarWidth barWidth, byte codeHeight);
         void InitializePrint();
     }
 }

--- a/ESC-POS-USB-NET/Printer.cs
+++ b/ESC-POS-USB-NET/Printer.cs
@@ -17,6 +17,12 @@ namespace ESC_POS_USB_NET.Printer
         private readonly string _printerName;
         private readonly IPrintCommand _command;
         private readonly string _codepage;
+
+
+        public byte[] Buffer { get { return _buffer; } }
+
+        public int DotsInLine { get; set; } = 576;
+
         public Printer(string printerName, string codepage= "IBM860")
         {
             _printerName = string.IsNullOrEmpty(printerName) ? "escpos.prn" : printerName.Trim();
@@ -269,9 +275,38 @@ namespace ESC_POS_USB_NET.Printer
             Append(_command.QrCode.Print(qrData, qrCodeSize));
         }
 
+        
+        public void QrCode(string qrData, QrCodeSize qrCodeSize, QrCodeErrorCorrection errorCorrection=QrCodeErrorCorrection.L, QrCodeModel qrModel=QrCodeModel.Model2, bool NoFun165=false)
+        {
+            Append(_command.QrCode.Print(qrData, qrCodeSize, errorCorrection, qrModel, NoFun165));
+        }
+
         public void Code128(string code, Positions printString = Positions.NotPrint)
         {
             Append(_command.BarCode.Code128(code,  printString));
+        }
+
+        /// <summary>
+        /// Create Code-128, charset C, binary data input.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        public void Code128(byte[] code, Positions printString = Positions.NotPrint)
+        {
+            Append(_command.BarCode.Code128(code, printString));
+        }
+
+        /// <summary>
+        /// Create Code-128 barcode with set charset, thin-bar width & code height (in dots).
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <param name="startCharset"></param>
+        /// <param name="barWidth"></param>
+        /// <param name="codeHeight">height in dots (default 40..50)</param>
+        public void Code128(string code, Positions printString = Positions.NotPrint, BarCodeCode128Charset startCharset=BarCodeCode128Charset.C, BarCodeBarWidth barWidth=BarCodeBarWidth.Width0250, byte codeHeight=50)
+        {
+            Append(_command.BarCode.Code128(code, printString, startCharset, barWidth, codeHeight));
         }
 
         public void Code39(string code, Positions printString=Positions.NotPrint)
@@ -279,10 +314,36 @@ namespace ESC_POS_USB_NET.Printer
             Append(_command.BarCode.Code39(code,  printString));
         }
 
+        /// <summary>
+        /// Create Code-39 with more settings: barcode thin-bar width and code height (in dots)
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <param name="barWidth"></param>
+        /// <param name="codeHeight">height in dots</param>
+        public void Code39(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50)
+        {
+            Append(_command.BarCode.Code39(code, printString, barWidth, codeHeight));
+        }
+
+
         public void Ean13(string code, Positions printString = Positions.NotPrint)
         {
             Append(_command.BarCode.Ean13(code,  printString));
         }
+
+        /// <summary>
+        /// Create EAN-13 barcode with more settings: thin bar width & code height (in dots)
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="printString"></param>
+        /// <param name="barWidth"></param>
+        /// <param name="codeHeight">in dots</param>
+        public void Ean13(string code, Positions printString = Positions.NotPrint, BarCodeBarWidth barWidth = BarCodeBarWidth.Width0250, byte codeHeight = 50)
+        {
+            Append(_command.BarCode.Ean13(code, printString, barWidth, codeHeight));
+        }
+
 
         public void InitializePrint()
         {
@@ -291,7 +352,7 @@ namespace ESC_POS_USB_NET.Printer
 
         public void Image(Bitmap image)
         {
-            Append(_command.Image.Print(image));
+            Append(_command.Image.Print(image, DotsInLine));
         }
         public void NormalLineHeight()
         {

--- a/ESC-POS-USB-NET/Printer.cs
+++ b/ESC-POS-USB-NET/Printer.cs
@@ -21,6 +21,9 @@ namespace ESC_POS_USB_NET.Printer
 
         public byte[] Buffer { get { return _buffer; } }
 
+        /// <summary>
+        /// Define printer printhead dots count
+        /// </summary>
         public int DotsInLine { get; set; } = 576;
 
         public Printer(string printerName, string codepage= "IBM860")
@@ -132,6 +135,11 @@ namespace ESC_POS_USB_NET.Printer
             BoldMode("Bold Text");
             UnderlineMode("Underlined text");
             Separator();
+            AppendWithoutLf("Text ");
+            ReverseModeNoLF("reversed");
+            Append(" and normal.");
+            ReverseMode("Reversed text line.");
+            Separator();
             ExpandedMode(PrinterModeState.On);
             Append("Expanded - 23 COLUMNS");
             Append("1...5...10...15...20..23");
@@ -220,6 +228,17 @@ namespace ESC_POS_USB_NET.Printer
             Append(_command.FontMode.Condensed(state));
         }
 
+        public void ReverseMode(string value)
+        {
+            Append(_command.FontMode.Reverse(value));
+        }
+
+        public void ReverseModeNoLF(string value)
+        {
+            Append(_command.FontMode.ReverseNoLF(value));
+        }
+
+
         public void NormalWidth()
         {
             Append(_command.FontWidth.Normal());
@@ -279,6 +298,11 @@ namespace ESC_POS_USB_NET.Printer
         public void QrCode(string qrData, QrCodeSize qrCodeSize, QrCodeErrorCorrection errorCorrection=QrCodeErrorCorrection.L, QrCodeModel qrModel=QrCodeModel.Model2, bool NoFun165=false)
         {
             Append(_command.QrCode.Print(qrData, qrCodeSize, errorCorrection, qrModel, NoFun165));
+        }
+
+        public void Code128(string code)
+        {
+            Append(_command.BarCode.Code128(code, Positions.NotPrint));
         }
 
         public void Code128(string code, Positions printString = Positions.NotPrint)
@@ -354,6 +378,12 @@ namespace ESC_POS_USB_NET.Printer
         {
             Append(_command.Image.Print(image, DotsInLine));
         }
+
+        public void Image(Bitmap image, bool scaleToWidth)
+        {
+            Append(_command.Image.Print(image, DotsInLine, scaleToWidth));
+        }
+
         public void NormalLineHeight()
         {
             Append(_command.LineHeight.Normal());

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ printer.Append("Text Normal");
 printer.BoldMode("Bold Text");
 printer.UnderlineMode("Underlined text");
 printer.Separator();
+printer.AppendWithoutLf("Text ");
+printer.ReverseModeNoLF("reversed");
+printer.Append(" and normal.");
+printer.ReverseMode("Reversed text line.");
+printer.Separator();
 printer.ExpandedMode(PrinterModeState.On);
 printer.Append("Expanded - 23 COLUMNS");
 printer.Append("1...5...10...15...20..23");
@@ -206,7 +211,10 @@ printer.PrintDocument();
 **Dependencies:**
 
 - .NETStandard 2.0
-- System.Drawing.Common (>= 4.6.0)
+  - System.Drawing.Common (>= 4.6.0)
+- NetFramework 4.5
+
+*Dual-build - no more need to add `netstandard2.0` if you want to use this library with generic netFramework.*
 
 **We recommend always using the latest version of ESC-POS-USB-NET to start your new projects**.
 
@@ -215,6 +223,10 @@ This project is currently in **Under Development**. Significant breaking changes
 ## 🧑‍🤝‍🧑 Contributing
 
 We welcome open an issue if you have any trouble.
+
+## :printer: Printers information
+
+You can look at file [SPECIFIC-PRINTER-INFO](SPECIFIC-PRINTER-INFO.md) to lookup some details about printers quirks (especially those cheap/clones from China).
 
 ## 📝 License
 

--- a/SPECIFIC-PRINTER-INFO.md
+++ b/SPECIFIC-PRINTER-INFO.md
@@ -3,11 +3,11 @@
 This is a place to add some details about different printers and what they support or don't - especially those cheap ones from aliexpress/banggood/dhgate/gearbest/taobao/and so on....
 
 Printer list:
-- MPT-II (USB&BT), mobile, 57mm media, *(Version: `B58G_v2.5.2e`)*
+- MPT-II (USB/BT), mobile, 57mm media, *(Version: `B58G_v2.5.2e`)*
 
 
 ----
-## MPT-II [Version: `B58G_v2.5.2e`]
+## :printer: MPT-II [Version: `B58G_v2.5.2e`]
 
 This is portable 57mm media thermal printer, it have USB (older models micro-USB, newer USB-C) & BT for communication. 
 
@@ -15,7 +15,7 @@ Pressing Feed & switching printer on will print test print & printer S/W info.
 
 In Windows it's recognized as some Generic usb printer and windows won't install automatically drivers. I get it working with XP-58 recipe printer drivers from Xprinter.
 
-**Specification:**
+#### **Specification:**
 - Power: 1x 18650 3,7V/2600mAh Li-Ion
 - media: recipe paper rolls width: 57mm , max. diameter about 40mm
 - Print width: 48mm (5mm margins from both sides)
@@ -27,7 +27,7 @@ In Windows it's recognized as some Generic usb printer and windows won't install
 - [System] Modify: `Jun 23 2023gd`
 - [Blue Tooth] Dev type: `040680`
 - [Blue Tooth] Baut: `460800` (Baud)
-- Code page: CP437 (U.S. Standard Europe)
+- Default code page: CP437 (U.S. Standard Europe)
 - Font:
   - 12x24 (Font A), 
   - 8x16 (Font B) - narrow variant - this font is not specified officially,
@@ -49,7 +49,7 @@ In Windows it's recognized as some Generic usb printer and windows won't install
 
 *I did not misspelled some words - those are printed that way from printer*
 
-**Printer 'quirks':**
+#### :small_orange_diamond: **Printer 'quirks':**
 
 If printer receive unknown command it will either: ignore it, print some random text or hang-up .
 

--- a/SPECIFIC-PRINTER-INFO.md
+++ b/SPECIFIC-PRINTER-INFO.md
@@ -46,6 +46,7 @@ In Windows it's recognized as some Generic usb printer and windows won't install
   - CODE93,
   - UPC-A & E,
   - QRCode - :warning: MPT-II don't support command "QrCode Model".
+- CPU: Barrot BR8551 (DayStar-Elec) - 32bit RISC @96MHz with BT5.2, 512KiB flash, 96KiB RAM, support OTA BT/UART, 29 GPIO, QFN-48 6x6mm
 
 *I did not misspelled some words - those are printed that way from printer*
 

--- a/SPECIFIC-PRINTER-INFO.md
+++ b/SPECIFIC-PRINTER-INFO.md
@@ -1,0 +1,65 @@
+# Some detail about printers
+
+This is a place to add some details about different printers and what they support or don't - especially those cheap ones from aliexpress/banggood/dhgate/gearbest/taobao/and so on....
+
+Printer list:
+- MPT-II (USB&BT), mobile, 57mm media, *(Version: `B58G_v2.5.2e`)*
+
+
+----
+## MPT-II [Version: `B58G_v2.5.2e`]
+
+This is portable 57mm media thermal printer, it have USB (older models micro-USB, newer USB-C) & BT for communication. 
+
+Pressing Feed & switching printer on will print test print & printer S/W info.
+
+In Windows it's recognized as some Generic usb printer and windows won't install automatically drivers. I get it working with XP-58 recipe printer drivers from Xprinter.
+
+**Specification:**
+- Power: 1x 18650 3,7V/2600mAh Li-Ion
+- media: recipe paper rolls width: 57mm , max. diameter about 40mm
+- Print width: 48mm (5mm margins from both sides)
+- Printhead resolution: 203dpi / 8dots per 1mm
+- Printhead dots: 384
+- Vertical step: 0,125mm (&#8539;mm ; same as print head resolution)
+- print speed max: 60mm/s (that's probably paper feed speed :sweat_smile:)
+- [System] Version: `B58G_v2.5.2e`
+- [System] Modify: `Jun 23 2023gd`
+- [Blue Tooth] Dev type: `040680`
+- [Blue Tooth] Baut: `460800` (Baud)
+- Code page: CP437 (U.S. Standard Europe)
+- Font:
+  - 12x24 (Font A), 
+  - 8x16 (Font B) - narrow variant - this font is not specified officially,
+  - 8x16 (Font C), 
+  - small (Font D) *(don't know what size, seems like it have 8x16dots)*
+- Charset tables:
+  - Default: 437 US/EU
+  - It might support up to 44 codepages (ISO8859-1/2/3..9/PC850/WPC1250/1251/...)
+- Barcodes:
+  - EAN-13 - you can supply it 12 or 13 digits (Lib require 13)
+  - CODE-39,
+  - CODE-128,
+  - EAN-8,
+  - INTERLEAVED 25 (ITF),
+  - CODEBAR,
+  - CODE93,
+  - UPC-A & E,
+  - QRCode - :warning: MPT-II don't support command "QrCode Model".
+
+*I did not misspelled some words - those are printed that way from printer*
+
+**Printer 'quirks':**
+
+If printer receive unknown command it will either: ignore it, print some random text or hang-up .
+
+Printer have issue with one command from QrCode command set - it don't support command "QrCode Model" (`GS(k<func:165>`) and print some text (e.g.: `2`) instead of this command.
+
+:warning: If you don't set in library `DotsInLine` for your printer and it's bigger than your printhead resolution(width in dots) then you'll get garbage in prints mixed with strips of your image.
+
+You can send data directly to printer skipping windows print-subsystem, use USB Endpoint 4 and USB URB transfer to send data to the printer. This might be easily done in Linux but in Windows it's PITA to do :expressionless:
+
+----
+
+
+#EOF


### PR DESCRIPTION
- I had some issues with my Chinese portable recipe printer (with USB/BT interfaces), so I did some fixes - mainly the one that define in image rendering how much printhead have dots - this one now can be set in Printer property and will be passed to image rendering routine - before it was hard-coded to 576:
https://github.com/mtmsuhail/ESC-POS-USB-NET/blob/ff50466659fdbba2208c50b109c2511888560da4/ESC-POS-USB-NET/Epson%20Commands/Image.cs#L16 

Now it can be set like this (before calling `prn.Image`):
```csharp
ESC_POS_USB_NET.Printer.Printer prn = new ESC_POS_USB_NET.Printer.Printer(eSelPrinter.Text);
prn.DotsInLine = Convert.ToInt32(ePrintingDots.Value);
```

- Also I have changed in project file `TargetFramework` so the build will be not only for `netstandard2.0` but also for `net45` - this should make easier to include only the library dll itself with netFramework application (net 4.5+)

- Another changes are in Code128 - now it's possible to specify charset A/B/C - like #38 ,and I took it a step further and added to all barcodes a options that allow to set length(height) and width (module) .

- Added also Reverse mode like in PR #47  .

- Next change is in Image routine again, I have added option `scaleToWidth`  - this behave almost like PR #68 , but my twist it that if image is wider than printhead width then image will be down-scaled to printing width. As for center feature, I think adding AlignCenter before image should do the trick (unfortunately my chinese MPT-II don't support centered images).

- Another changes are in regards to QrCode - many of those changes are from PR #22 , I have added a function that allow to set size, error correction level, and option to disable **Set QrCode Model** command: `GS(k<func165>` , my printer instead ignoring this command it print a number `2` 😒 - it took me a while to figure it out (I had for a while: wth this 2 is coming from 😠 )

- Lastly I have updated README , added CHANGELOG file and file `SPECIFIC-PRINTER-INFO` where we maybe put together some information about different printers and theirs quirks.